### PR TITLE
Feature/single component improvement

### DIFF
--- a/src/Api/UnitApi.php
+++ b/src/Api/UnitApi.php
@@ -59,7 +59,9 @@ class UnitApi
          */
         $page = 1;
         do {
-            $response = self::$client->request('GET', $translation->units_list_url.'?'.http_build_query(['page' => $page]));
+            $url = $translation->units_list_url.
+                (null === parse_url($translation->units_list_url, PHP_URL_QUERY) ? '?' : '&').http_build_query(['page' => $page]);
+            $response = self::$client->request('GET', $url);
 
             if (200 !== $response->getStatusCode()) {
                 self::$logger->debug($response->getStatusCode().': '.$response->getContent(false));

--- a/src/PushullProvider.php
+++ b/src/PushullProvider.php
@@ -68,6 +68,14 @@ class PushullProvider implements ProviderInterface
         return sprintf('pushull://%s', $this->endpoint);
     }
 
+    protected function loadFirstDomain(array $domains): void
+    {
+        // If we try to fetch only one domain, don't load them all
+        if (1 === count($domains) && ($domain = reset($domains))) {
+            ComponentApi::getOneComponent(self::domainNormalize($domain));
+        }
+    }
+
     private static function domainNormalize(string $domain): string
     {
         return str_replace('.', '_dot_', $domain);
@@ -85,6 +93,8 @@ class PushullProvider implements ProviderInterface
     {
         /** @var MessageCatalogue $catalogue */
         foreach ($translatorBag->getCatalogues() as $catalogue) {
+            $this->loadFirstDomain($catalogue->getDomains());
+
             foreach ($catalogue->getDomains() as $domain) {
                 if (0 === count($catalogue->all($domain))) {
                     $this->logger->info('Catalog is empty for '.$domain);
@@ -135,6 +145,9 @@ class PushullProvider implements ProviderInterface
             $domains = array_keys(ComponentApi::getComponents());
         }
 
+        // If we try to fetch only one domain, don't load them all
+        $this->loadFirstDomain($domains);
+
         $translatorBag = new TranslatorBag();
 
         foreach ($domains as $domain) {
@@ -161,6 +174,8 @@ class PushullProvider implements ProviderInterface
     {
         /** @var MessageCatalogue $catalogue */
         foreach ($translatorBag->getCatalogues() as $catalogue) {
+            $this->loadFirstDomain($catalogue->getDomains());
+
             foreach ($catalogue->getDomains() as $domain) {
                 if (0 === count($catalogue->all($domain))) {
                     continue;

--- a/tests/Api/ComponentApiTest.php
+++ b/tests/Api/ComponentApiTest.php
@@ -37,7 +37,7 @@ class ComponentApiTest extends ApiTest
     private function getGetComponentsResponse(array $results): callable
     {
         return $this->getResponse(
-            '/projects/project/components/',
+            '/projects/project/components/?page=1',
             'GET',
             '',
             (string) json_encode(['results' => $results])

--- a/tests/Api/UnitApiTest.php
+++ b/tests/Api/UnitApiTest.php
@@ -36,7 +36,7 @@ class UnitApiTest extends ApiTest
     private function getGetUnitsResponse(Translation $translation, array $results): callable
     {
         return $this->getResponse(
-            $translation->units_list_url,
+            $translation->units_list_url.'&page=1',
             'GET',
             '',
             (string) json_encode(['results' => $results])

--- a/tests/PushullProviderTest.php
+++ b/tests/PushullProviderTest.php
@@ -79,7 +79,7 @@ class PushullProviderTest extends ProviderTestCase
     private function getGetComponentsResponse(array $results): callable
     {
         return $this->getResponse(
-            'https://web.pushull.com/acme/api/projects/project/components/',
+            'https://web.pushull.com/acme/api/projects/project/components/?page=1',
             'GET',
             '',
             (string) json_encode(['results' => $results])
@@ -153,7 +153,7 @@ class PushullProviderTest extends ProviderTestCase
     private function getGetUnitsResponse(string $url, array $results): callable
     {
         return $this->getResponse(
-            $url,
+            $url.'&page=1',
             'GET',
             '',
             (string) json_encode(['results' => $results])


### PR DESCRIPTION
test: Fix broken unit test since component and unit API are using paginated option

feat: Do not load all components when trying to write/read a single component with Pushull commands.
There is 2 use cases in our application :
- Fetch and update all domains: Load all components using /project/$project/components API and paginate over it (multiple API calls).
- Fetch and update one domain:  Load a single component using /components/$project/$component API (one API call). As this update is done while an HTTP request, we can't afford to hit this API multiple times for nothing.

Last thing, if method **ComponentApi::getComponents** and **ComponentApi::getOneComponent** are called in the same process, we need to make sure **getComponents** stil return all components, even if **getOneComponent** have been called first.